### PR TITLE
Added shebang and made zora.py executable for linux command line usage.

### DIFF
--- a/zora.py
+++ b/zora.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import sys
 from absl import app
 from absl import flags


### PR DESCRIPTION
This change allows someone to clone the repository and execute it with `./zora.py <arguments>` rather than the more verbose `python3 zora.py arguments` directly from the linux command prompt. This will be especially useful for users who are using a RetroPie.